### PR TITLE
fix train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -172,7 +172,8 @@ if __name__ == '__main__':
         config = yaml.load(f)
 
     batch_size = config.pop('batch_size')
-    get_dataloader = partial(DataLoader, batch_size=batch_size, num_workers=cpu_count(), shuffle=True, drop_last=True)
+    # get_dataloader = partial(DataLoader, batch_size=batch_size, num_workers=cpu_count(), shuffle=True, drop_last=True)
+    get_dataloader = partial(DataLoader, batch_size=batch_size, shuffle=True, drop_last=True)
 
     datasets = map(config.pop, ('train', 'val'))
     datasets = map(PairedDataset.from_config, datasets)


### PR DESCRIPTION
train.pyの並列化コードを削除しました。
まだDouble GANにおけるpatch GANのlossが70x70で計算されていないであろう問題が修正されずに残っています。